### PR TITLE
ios17 komga download fix

### DIFF
--- a/src/Paperback/Paperback.ts
+++ b/src/Paperback/Paperback.ts
@@ -104,7 +104,9 @@ export class KomgaRequestInterceptor implements SourceInterceptor {
         // raising an error in getAuthorizationString when we check for its existence
         // Thus we only inject an authorizationString if none are defined in the request
         if (request.headers.authorization === undefined) {
-            request.headers.authorization = await getAuthorizationString(this.stateManager)
+            request.headers = {
+              'authorization': await getAuthorizationString(this.stateManager)
+            }
         }
         return request
     }


### PR DESCRIPTION
After doing some testing for whatever reason the authorization section of the header never gets changed if you just do `request.headers.authorization = getAuthorizationString(this.stateManager)`, causing the authorization token to never be set seemingly specifically when downloading things, at least on my ipad. Setting `request.headers` to a new Record seems to resolve this, for whatever reason.

Notably this fixes PaperBack-iOS/app#665 at least for me.