### PR TITLE
fix(Komga): improve chapter list display and metadata

### DIFF
--- a/src/Komga/komga.ts
+++ b/src/Komga/komga.ts
@@ -377,7 +377,7 @@ export class KomgaExtension implements IKomgaExtension {
         volume: 0,
         langCode: book.size,
         title: '',
-        creationDate: new Date(book.fileLastModified),
+        creationDate: book.metadata.releaseDate ? new Date(book.metadata.releaseDate) : new Date(book.fileLastModified),
         sortingIndex: book.metadata.numberSort,
         sourceManga: sourceManga,
         version: languageCode,

--- a/src/Komga/komga.ts
+++ b/src/Komga/komga.ts
@@ -376,7 +376,7 @@ export class KomgaExtension implements IKomgaExtension {
         chapNum: parseFloat(book.metadata.number),
         volume: 0,
         langCode: book.size,
-        title: (book.metadata.title ?? '').replace(/^chapter\s+[\d.]+[:\s-]+/i, '').trim(),
+        title: (book.metadata.title ?? '').replace(/^chapter\s+[\d.]+[:\s-]*/i, '').trim(),
         creationDate: book.metadata.releaseDate ? new Date(book.metadata.releaseDate) : new Date(book.fileLastModified),
         sortingIndex: book.metadata.numberSort,
         sourceManga: sourceManga,

--- a/src/Komga/komga.ts
+++ b/src/Komga/komga.ts
@@ -376,7 +376,7 @@ export class KomgaExtension implements IKomgaExtension {
         chapNum: parseFloat(book.metadata.number),
         volume: 0,
         langCode: book.size,
-        title: '',
+        title: (book.metadata.title ?? '').replace(/^chapter\s+[\d.]+[:\s-]+/i, '').trim(),
         creationDate: book.metadata.releaseDate ? new Date(book.metadata.releaseDate) : new Date(book.fileLastModified),
         sortingIndex: book.metadata.numberSort,
         sourceManga: sourceManga,

--- a/src/Komga/komga.ts
+++ b/src/Komga/komga.ts
@@ -374,8 +374,9 @@ export class KomgaExtension implements IKomgaExtension {
       chapters.push({
         chapterId: book.id,
         chapNum: parseFloat(book.metadata.number),
+        volume: 0,
         langCode: book.size,
-        title: `${book.metadata.title}`,
+        title: '',
         creationDate: new Date(book.fileLastModified),
         sortingIndex: book.metadata.numberSort,
         sourceManga: sourceManga,

--- a/src/Komga/komga.ts
+++ b/src/Komga/komga.ts
@@ -150,12 +150,14 @@ export class KomgaExtension implements IKomgaExtension {
         primaryTitle: metadata.title,
         secondaryTitles: [],
         contentRating: ContentRating.EVERYONE,
-
         status: parseMangaStatus(metadata.status),
         artist: artists.join(', '),
         author: authors.join(', '),
         synopsis: metadata.summary ? metadata.summary : booksMetadata.summary,
         tagGroups: tagSections,
+        additionalInfo: {
+          language: metadata.language,
+        },
       },
     }
   }

--- a/src/Komga/komga.ts
+++ b/src/Komga/komga.ts
@@ -379,7 +379,7 @@ export class KomgaExtension implements IKomgaExtension {
         volume: 0,
         langCode: book.size,
         title: (book.metadata.title ?? '').replace(/^chapter\s+[\d.]+[:\s-]*/i, '').trim(),
-        creationDate: book.metadata.releaseDate ? new Date(book.metadata.releaseDate) : new Date(book.fileLastModified),
+        publishDate: book.metadata.releaseDate ? new Date(book.metadata.releaseDate) : new Date(book.fileLastModified),
         sortingIndex: book.metadata.numberSort,
         sourceManga: sourceManga,
         version: languageCode,

--- a/src/Komga/pbconfig.ts
+++ b/src/Komga/pbconfig.ts
@@ -5,7 +5,7 @@ import {
 } from '@paperback/types'
 
 export default {
-  version: '2.2',
+  version: '2.3',
   name: 'Komga',
   icon: 'icon.png',
   developers: [

--- a/src/Komga_2/pbconfig.ts
+++ b/src/Komga_2/pbconfig.ts
@@ -5,7 +5,7 @@ import {
 } from '@paperback/types'
 
 export default {
-  version: '2.2',
+  version: '2.3',
   name: 'Komga_2',
   icon: 'icon.png',
   developers: [


### PR DESCRIPTION
## Summary

- **Suppress "Vol. TBA"** — set `volume: 0` so Paperback no longer shows the placeholder when no volume data exists in Komga
- **Clean chapter titles** — strips the redundant `"Chapter N:"` / `"Chapter N -"` prefix from `metadata.title`; chapters with extra text (e.g. `"Chapter 257: Encounter Anomaly"`) display as `"Encounter Anomaly"`, while plain `"Chapter 112"` titles display as just `"Chapter 112"`
- **Accurate release dates** — uses `metadata.releaseDate` (sourced from ComicInfo.xml via komf) with fallback to `fileLastModified`; switched from `creationDate` to `publishDate` to match the Paperback 0.9 API
- **Language metadata** — populates `additionalInfo.language` from series `metadata.language` so chapter language codes resolve from Komga instead of always falling back to `UNKNOWN`
- **Version bump** — `2.2` → `2.3`